### PR TITLE
Backport improvements

### DIFF
--- a/source/Stargate-Examples-Tests/PetStoreAPITest.class.st
+++ b/source/Stargate-Examples-Tests/PetStoreAPITest.class.st
@@ -135,7 +135,10 @@ PetStoreAPITest >> testConflict [
 
 	self newClient
 		url: self baseUrl / 'orders' asUrl;
-		entity: (ZnEntity with: '{"date":"2018-10-24T18:05:46.418Z","pet":"https://api.example.com/pets/1"}' ofType: self ordersSpec orderVersion1dot0dot0MediaType);
+		entity:
+			( ZnEntity
+				with: '{"date":"2018-10-24T18:05:46.418Z","pet":"https://api.example.com/pets/1"}'
+				ofType: self ordersSpec orderVersion1dot0dot0MediaType );
 		post.
 
 	self newClient
@@ -145,12 +148,14 @@ PetStoreAPITest >> testConflict [
 	self
 		should: [ self newClient
 				url: self baseUrl / 'orders/1/complete' asUrl;
-				post ]
+				post
+			]
 		raise: ZnHttpUnsuccessful
 		withExceptionDo: [ :error | 
 			self
 				assert: error response isError;
-				assert: error response code equals: 409 ]
+				assert: error response code equals: 409
+			]
 ]
 
 { #category : #tests }

--- a/source/Stargate-Examples-Tests/PetsRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/PetsRESTfulControllerTest.class.st
@@ -74,7 +74,9 @@ PetsRESTfulControllerTest >> requestToCreatePetFrom: json [
 { #category : #'private - support' }
 PetsRESTfulControllerTest >> requestToDeletePetIdentifiedBy: anIdentifier [
 
-	^ TeaRequest fromZnRequest: (ZnRequest delete: (self urlForResourceIdentifiedBy: anIdentifier)) pathParams: {(#identifier -> anIdentifier)} asDictionary
+	^ TeaRequest
+		fromZnRequest: ( ZnRequest delete: ( self urlForResourceIdentifiedBy: anIdentifier ) )
+		pathParams: {( #identifier -> anIdentifier )} asDictionary
 ]
 
 { #category : #'private - support' }
@@ -102,27 +104,21 @@ PetsRESTfulControllerTest >> requestToUpdatePetIdentifiedBy: anIdentifier nameTo
 { #category : #'private - support' }
 PetsRESTfulControllerTest >> requestToUpdatePetIdentifiedBy: anIdentifier nameTo: aName using: anETag [
 
-	^ TeaRequest
-		fromZnRequest:
-			((ZnRequest patch: (self urlForResourceIdentifiedBy: anIdentifier))
-				setAccept: self defaultPetMediaType;
-				setIfMatchTo: anETag;
-				entity: (ZnEntity with: ('{"name":"<1s>"}' expandMacrosWith: aName) type: self defaultPetMediaType);
-				yourself)
-		pathParams: {(#identifier -> anIdentifier)} asDictionary
+	^ self
+		requestToPATCHResourceIdentifiedBy: anIdentifier
+		with: ( '{"name":"<1s>"}' expandMacrosWith: aName )
+		accepting: self defaultPetMediaType
+		conditionalTo: anETag
 ]
 
 { #category : #'private - support' }
 PetsRESTfulControllerTest >> requestToUpdatePetIdentifiedBy: anIdentifier statusTo: aStatus [
 
-	^ TeaRequest
-		fromZnRequest:
-			((ZnRequest patch: (self urlForResourceIdentifiedBy: anIdentifier))
-				setAccept: self defaultPetMediaType;
-				setIfMatchTo: (self entityTagOfPetIdentifiedBy: anIdentifier);
-				entity: (ZnEntity with: ('{"status":"<1s>"}' expandMacrosWith: aStatus) type: self defaultPetMediaType);
-				yourself)
-		pathParams: {(#identifier -> anIdentifier)} asDictionary
+	^ self
+		requestToPATCHResourceIdentifiedBy: anIdentifier
+		with: ( '{"status":"<1s>"}' expandMacrosWith: aStatus )
+		accepting: self defaultPetMediaType
+		conditionalTo: ( self entityTagOfPetIdentifiedBy: anIdentifier )
 ]
 
 { #category : #running }

--- a/source/Stargate-Examples/PetOrdersRESTfulController.class.st
+++ b/source/Stargate-Examples/PetOrdersRESTfulController.class.st
@@ -41,7 +41,7 @@ PetOrdersRESTfulController >> createOrderBasedOn: anHttpRequest within: aContext
 ]
 
 { #category : #'private - accessing' }
-PetOrdersRESTfulController >> entityTagOf: aPetOrder encodedAs: mediaType [
+PetOrdersRESTfulController >> entityTagOf: aPetOrder encodedAs: mediaType within: aContext [
 
 	^ ZnETag
 		with:
@@ -94,7 +94,7 @@ PetOrdersRESTfulController >> lastModificationOf: aPetOrder [
 ]
 
 { #category : #'private - accessing' }
-PetOrdersRESTfulController >> locationOf: aPetOrder [
+PetOrdersRESTfulController >> locationOf: aPetOrder within: aContext [
 
 	| baseUrl |
 
@@ -105,20 +105,23 @@ PetOrdersRESTfulController >> locationOf: aPetOrder [
 ]
 
 { #category : #'private - accessing' }
-PetOrdersRESTfulController >> mediaControlsFor: order [
+PetOrdersRESTfulController >> mediaControlsFor: order within: aContext [
 
 	| status |
 
-	status := orderStatus at: (orderById keyAtValue: order).
+	status := orderStatus at: ( orderById keyAtValue: order ).	
 	"In the real life you don't do a case. This is a toy example"
 	status = 'registered'
-		ifTrue: [ ^ (super mediaControlsFor: order)
+		ifTrue: [ ^ ( super mediaControlsFor: order within: aContext )
 				,
-					{('cancel' -> ((self locationOf: order) / 'cancel' asUrl)).
-					('complete' -> ((self locationOf: order) / 'complete' asUrl))} ].
+					{( 'cancel' -> ( ( self locationOf: order within: aContext ) / 'cancel' asUrl ) ).
+					( 'complete' -> ( ( self locationOf: order within: aContext ) / 'complete' asUrl ) )}
+			].
 	status = 'completed'
-		ifTrue: [ ^ (super mediaControlsFor: order) , {('cancel' -> ((self locationOf: order) / 'cancel' asUrl))} ].
-	^ super mediaControlsFor: order
+		ifTrue: [ ^ ( super mediaControlsFor: order within: aContext )
+				, {( 'cancel' -> ( ( self locationOf: order within: aContext ) / 'cancel' asUrl ) )}
+			].
+	^ super mediaControlsFor: order within: aContext
 ]
 
 { #category : #'private - accessing' }
@@ -181,7 +184,11 @@ PetOrdersRESTfulController >> updateOrderStatusBasedOn: anHttpRequest within: aC
 
 	self handleConflictsIn: anUpdateBlock.
 	response := ZnResponse noContent.
-	self putEntityTagOf: (self orderIdentifiedUsing: anHttpRequest) encodedAs: self specification orderVersion1dot0dot0MediaType in: response.
+	self
+		putEntityTagOf: ( self orderIdentifiedUsing: anHttpRequest )
+		encodedAs: self specification orderVersion1dot0dot0MediaType
+		in: response
+		within: aContext.
 	^ response
 ]
 

--- a/source/Stargate-Examples/PetOrdersRESTfulControllerSpecification.class.st
+++ b/source/Stargate-Examples/PetOrdersRESTfulControllerSpecification.class.st
@@ -49,7 +49,10 @@ PetOrdersRESTfulControllerSpecification >> addJsonEncoderVersion1dot0dot0Mapping
 { #category : #routes }
 PetOrdersRESTfulControllerSpecification >> cancelOrderRoute [
 
-	^ RouteSpecification handling: #POST at: self cancelTemplate evaluating: [ :service :httpRequest :context | service cancelOrderBasedOn: httpRequest within: context ]
+	^ RouteSpecification
+		handling: #POST
+		at: self cancelTemplate
+		evaluating: [ :controller :httpRequest :context | controller cancelOrderBasedOn: httpRequest within: context ]
 ]
 
 { #category : #'private - accessing' }
@@ -61,7 +64,10 @@ PetOrdersRESTfulControllerSpecification >> cancelTemplate [
 { #category : #routes }
 PetOrdersRESTfulControllerSpecification >> completeOrderRoute [
 
-	^ RouteSpecification handling: #POST at: self completeTemplate evaluating: [ :service :httpRequest :context | service completeOrderBasedOn: httpRequest within: context ]
+	^ RouteSpecification
+		handling: #POST
+		at: self completeTemplate
+		evaluating: [ :controller :httpRequest :context | controller completeOrderBasedOn: httpRequest within: context ]
 ]
 
 { #category : #'private - accessing' }
@@ -73,7 +79,10 @@ PetOrdersRESTfulControllerSpecification >> completeTemplate [
 { #category : #routes }
 PetOrdersRESTfulControllerSpecification >> createOrderRoute [
 
-	^ RouteSpecification handling: #POST at: self endpoint evaluating: [ :service :httpRequest :context | service createOrderBasedOn: httpRequest within: context ]
+	^ RouteSpecification
+		handling: #POST
+		at: self endpoint
+		evaluating: [ :controller :httpRequest :context | controller createOrderBasedOn: httpRequest within: context ]
 ]
 
 { #category : #'private - accessing' }
@@ -85,7 +94,10 @@ PetOrdersRESTfulControllerSpecification >> endpoint [
 { #category : #routes }
 PetOrdersRESTfulControllerSpecification >> getOrderRoute [
 
-	^ RouteSpecification handling: #GET at: self idTemplate evaluating: [ :service :httpRequest :context | service getOrderBasedOn: httpRequest within: context ]
+	^ RouteSpecification
+		handling: #GET
+		at: self idTemplate
+		evaluating: [ :controller :httpRequest :context | controller getOrderBasedOn: httpRequest within: context ]
 ]
 
 { #category : #'private - accessing' }

--- a/source/Stargate-Examples/PetsRESTfulController.class.st
+++ b/source/Stargate-Examples/PetsRESTfulController.class.st
@@ -60,7 +60,7 @@ PetsRESTfulController >> deletePetBasedOn: anHttpRequest within: aContext [
 ]
 
 { #category : #'private - accessing' }
-PetsRESTfulController >> entityTagOf: aPet encodedAs: mediaType [
+PetsRESTfulController >> entityTagOf: aPet encodedAs: mediaType within: aContext [
 
 	^ ZnETag
 		with:
@@ -130,7 +130,7 @@ PetsRESTfulController >> lastModificationOf: aPet [
 ]
 
 { #category : #'private - accessing' }
-PetsRESTfulController >> locationOf: aPet [
+PetsRESTfulController >> locationOf: aPet within: aContext [
 
 	| baseUrl |
 
@@ -208,14 +208,19 @@ PetsRESTfulController >> updatePetBasedOn: anHttpRequest within: aContext [
 		get: [ | resource pet |
 
 			pet := self petIdentifiedUsing: anHttpRequest.
-			self assert: etag matchesEntityTagOf: pet encodedAs: anHttpRequest contentType.
+			self
+				assert: etag
+				matchesEntityTagOf: pet
+				encodedAs: anHttpRequest contentType
+				within: aContext.
 			resource := self
 				decode: anHttpRequest contents
 				at: self specification petMappingKey
 				from: anHttpRequest contentType
 				within: aContext.
 			self updatePet: pet with: resource.
-			pet ]
+			pet
+			]
 		encodedUsing: self specification petMappingKey
 		basedOn: anHttpRequest
 		within: aContext

--- a/source/Stargate-Examples/PetsRESTfulControllerSpecification.class.st
+++ b/source/Stargate-Examples/PetsRESTfulControllerSpecification.class.st
@@ -11,7 +11,9 @@ Class {
 PetsRESTfulControllerSpecification >> addJsonDecoderVersion1dot0dot0MappingIn: aBuilder [
 
 	aBuilder
-		addDefaultRuleToDecode: self petVersion1dot0dot0MediaType to: self petMappingKey using: [ :json | NeoJSONObject fromString: json ]
+		addDefaultRuleToDecode: self petVersion1dot0dot0MediaType
+		to: self petMappingKey
+		using: [ :json | NeoJSONObject fromString: json ]
 ]
 
 { #category : #'mapping rules' }

--- a/source/Stargate-Model-Tests/RESTfulControllerAcceptNegotiatorTest.class.st
+++ b/source/Stargate-Model-Tests/RESTfulControllerAcceptNegotiatorTest.class.st
@@ -69,7 +69,9 @@ RESTfulControllerAcceptNegotiatorTest >> testMissingVersionSelectsTheNewOne [
 RESTfulControllerAcceptNegotiatorTest >> testRFC2616Sec14 [
 
 	self
-		assertBestRepresentationFor: self rfcHeader given: {'text/html;level=1' asMediaType} is: 'text/html;level=1' asMediaType;
+		assertBestRepresentationFor: self rfcHeader
+			given: {'text/html;level=1' asMediaType}
+			is: 'text/html;level=1' asMediaType;
 		assertBestRepresentationFor: self pearAcceptHeader
 			given:
 			{'application/xml' asMediaType.

--- a/source/Stargate-Model-Tests/ReflectiveRoutesConfiguratorTest.class.st
+++ b/source/Stargate-Model-Tests/ReflectiveRoutesConfiguratorTest.class.st
@@ -44,16 +44,15 @@ ReflectiveRoutesConfiguratorTest >> testConfiguringCrossOriginResourceSharingAwa
 ]
 
 { #category : #tests }
-ReflectiveRoutesConfiguratorTest >> testConfiguringPetsWebServiceRoutes [
+ReflectiveRoutesConfiguratorTest >> testConfiguringPetsControllerRoutes [
 
-	| teapot webService |
+	| teapot controller |
 
 	teapot := Teapot on.
 
-	webService := PetsRESTfulController new.
+	controller := PetsRESTfulController new.
 
-	(ReflectiveRoutesConfigurator appliedTo: teapot) 
-		addRoutesOf: webService.
+	( ReflectiveRoutesConfigurator appliedTo: teapot ) addRoutesOf: controller.
 
 	self assert: teapot routes size equals: 5
 ]

--- a/source/Stargate-Model-Tests/ResourceRESTfulControllerTest.class.st
+++ b/source/Stargate-Model-Tests/ResourceRESTfulControllerTest.class.st
@@ -58,6 +58,36 @@ ResourceRESTfulControllerTest >> requestToGetResourceIdentifiedBy: anIdentifier 
 ]
 
 { #category : #'private - support' }
+ResourceRESTfulControllerTest >> requestToGetSubresource: aSubresourceEndpoint identifiedBy: anIdentifier accepting: anAcceptHeader [
+
+	^ TeaRequest
+		fromZnRequest:
+			( ( ZnRequest get: ( self urlForResourceIdentifiedBy: anIdentifier ) / aSubresourceEndpoint )
+				setAccept: anAcceptHeader;
+				yourself )
+		pathParams:
+			( SmallDictionary new
+				at: #identifier put: anIdentifier;
+				yourself )
+]
+
+{ #category : #'private - support' }
+ResourceRESTfulControllerTest >> requestToPATCHResourceIdentifiedBy: anIdentifier with: aRequestBody accepting: anAcceptHeader conditionalTo: anETag [
+
+	^ TeaRequest
+		fromZnRequest:
+			( ( ZnRequest patch: ( self urlForResourceIdentifiedBy: anIdentifier ) )
+				setAccept: anAcceptHeader;
+				setIfMatchTo: anETag;
+				entity: ( ZnEntity with: aRequestBody type: anAcceptHeader );
+				yourself )
+		pathParams:
+			( SmallDictionary new
+				at: #identifier put: anIdentifier;
+				yourself )
+]
+
+{ #category : #'private - support' }
 ResourceRESTfulControllerTest >> requestToPOST: content as: aMediaType [
 
 	^ TeaRequest
@@ -90,7 +120,7 @@ ResourceRESTfulControllerTest >> setUpResourceController [
 { #category : #'private - support' }
 ResourceRESTfulControllerTest >> urlForResourceIdentifiedBy: anIdentifier [
 
-	^ self resourceUrl / anIdentifier printString asZnUrl
+	^ self resourceUrl / anIdentifier asString asZnUrl
 ]
 
 { #category : #'private - support' }

--- a/source/Stargate-Model-Tests/ZnUrlTest.class.st
+++ b/source/Stargate-Model-Tests/ZnUrlTest.class.st
@@ -1,0 +1,29 @@
+"
+I'm a test for extensions on ZnUrl
+"
+Class {
+	#name : #ZnUrlTest,
+	#superclass : #TestCase,
+	#category : #'Stargate-Model-Tests-Zinc'
+}
+
+{ #category : #tests }
+ZnUrlTest >> testQueryAtPutUrl [
+
+	self
+		assert:
+			( 'https://api.example.com/pets' asUrl
+				queryAt: 'relatedTo'
+				putUrl: 'https://api.example.com/pets/99' )
+		equals: 'https://api.example.com/pets?relatedTo=https%253A%252F%252Fapi.example.com%252Fpets%252F99' asUrl
+]
+
+{ #category : #tests }
+ZnUrlTest >> testStartLimit [
+
+	self
+		assert: ( 'https://api.example.com/pets' asUrl start: 1 limit: 10 )
+			equals: 'https://api.example.com/pets?limit=10&start=1' asUrl;
+		assert: ( 'https://api.example.com/pets' asUrl start: 1 limit: 10 )
+			equals: 'https://api.example.com/pets?start=1&limit=10' asUrl
+]

--- a/source/Stargate-Model/HypermediaDrivenRESTfulControllerPolicy.class.st
+++ b/source/Stargate-Model/HypermediaDrivenRESTfulControllerPolicy.class.st
@@ -19,14 +19,23 @@ HypermediaDrivenRESTfulControllerPolicy class >> for: aResourceController [
 { #category : #configuring }
 HypermediaDrivenRESTfulControllerPolicy >> holdCollection: resourceCollection controlsBasedOn: httpRequest within: context [
 
-	context holdAsHypermediaControls: (resourceController paginationPolicy addPaginationControlsTo: {('self' -> httpRequest absoluteUrl)} within: context).
-	resourceCollection do: [ :resource | context holdAsHypermediaControls: (resourceController mediaControlsFor: resource) forSubresource: resource ]
+	context
+		holdAsHypermediaControls:
+			( resourceController paginationPolicy
+				addPaginationControlsTo: {( 'self' -> httpRequest absoluteUrl )}
+				within: context ).
+	resourceCollection
+		do: [ :resource | 
+			context
+				holdAsHypermediaControls: ( resourceController mediaControlsFor: resource within: context )
+				forSubresource: resource
+			]
 ]
 
 { #category : #configuring }
 HypermediaDrivenRESTfulControllerPolicy >> holdResource: resource controlsWithin: context [
 
-	context holdAsHypermediaControls: (resourceController mediaControlsFor: resource)
+	context holdAsHypermediaControls: ( resourceController mediaControlsFor: resource within: context )
 ]
 
 { #category : #initialization }

--- a/source/Stargate-Model/PaginationSpecification.class.st
+++ b/source/Stargate-Model/PaginationSpecification.class.st
@@ -14,9 +14,11 @@ Class {
 { #category : #'Instance creation' }
 PaginationSpecification class >> startingAt: aNumber limitedTo: aLimit [
 
-	AssertionChecker enforce: [ aLimit strictlyPositive ] because: 'The page limit must be positive' raising: InstanceCreationFailed.
-	"We're forgiving with the starting index"
-	^ self new initializeStartingAt: (aNumber max: 1) limitedTo: aLimit
+	AssertionChecker
+		enforce: [ aLimit strictlyPositive ]
+		because: 'The page limit must be positive'
+		raising: InstanceCreationFailed.	"We're forgiving with the starting index"
+	^ self new initializeStartingAt: ( aNumber max: 1 ) limitedTo: aLimit
 ]
 
 { #category : #accessing }

--- a/source/Stargate-Model/RESTfulControllerDoNotRespondCreatedEntityPolicy.class.st
+++ b/source/Stargate-Model/RESTfulControllerDoNotRespondCreatedEntityPolicy.class.st
@@ -25,5 +25,5 @@ RESTfulControllerDoNotRespondCreatedEntityPolicy >> initializeFor: aResourceCont
 { #category : #processing }
 RESTfulControllerDoNotRespondCreatedEntityPolicy >> responseFor: aResource decodedUsing: aKey basedOn: anHttpRequest within: aContext [
 
-	^ ZnResponse created: ( resourceController locationOf: aResource )
+	^ ZnResponse created: ( resourceController locationOf: aResource within: aContext )
 ]

--- a/source/Stargate-Model/RESTfulControllerPaginateCollectionsPolicy.class.st
+++ b/source/Stargate-Model/RESTfulControllerPaginateCollectionsPolicy.class.st
@@ -38,7 +38,12 @@ RESTfulControllerPaginateCollectionsPolicy >> affect: response within: aContext 
 { #category : #applying }
 RESTfulControllerPaginateCollectionsPolicy >> evaluateQuery: aQueryEvaluationBlock basedOn: anHttpRequest [
 
-	^ resourceController evaluateQuery: [ aQueryEvaluationBlock cull: (self paginationFrom: anHttpRequest) ]
+	| pagination |
+
+	pagination := [ self paginationFrom: anHttpRequest ]
+		on: InstanceCreationFailed
+		do: [ :error | HTTPClientError signalBadRequest: error messageText ].
+	^ resourceController evaluateQuery: [ aQueryEvaluationBlock cull: pagination ]
 ]
 
 { #category : #initialization }

--- a/source/Stargate-Model/RESTfulControllerRespondCreatedEntityPolicy.class.st
+++ b/source/Stargate-Model/RESTfulControllerRespondCreatedEntityPolicy.class.st
@@ -25,13 +25,21 @@ RESTfulControllerRespondCreatedEntityPolicy >> initializeFor: aResourceControlle
 { #category : #processing }
 RESTfulControllerRespondCreatedEntityPolicy >> responseFor: aResource decodedUsing: aKey basedOn: anHttpRequest within: aContext [
 
+	| response |
+
 	resourceController hypermediaPolicy holdResource: aResource controlsWithin: aContext.
-	^ ZnResponse
-		created: ( resourceController locationOf: aResource )
+	response := ZnResponse
+		created: ( resourceController locationOf: aResource within: aContext )
 		entity:
 			( resourceController
 				encode: aResource
 				at: aKey
 				to: anHttpRequest contentType
-				within: aContext )
+				within: aContext ).
+	resourceController
+		putEntityTagOf: aResource
+		encodedAs: anHttpRequest contentType
+		in: response
+		within: aContext.
+	^ response
 ]

--- a/source/Stargate-Model/ResourceRESTfulController.class.st
+++ b/source/Stargate-Model/ResourceRESTfulController.class.st
@@ -20,9 +20,9 @@ Class {
 }
 
 { #category : #'private - asserting' }
-ResourceRESTfulController >> assert: etag matchesEntityTagOf: entity encodedAs: mediaType [
+ResourceRESTfulController >> assert: etag matchesEntityTagOf: entity encodedAs: mediaType within: aContext [
 
-	(etag = (self entityTagOf: entity encodedAs: mediaType))
+	etag = ( self entityTagOf: entity encodedAs: mediaType within: aContext )
 		ifFalse: [ HTTPClientError signalPreconditionFailed ]
 ]
 
@@ -47,7 +47,7 @@ ResourceRESTfulController >> encode: theResource at: aKey to: targetMediaType wi
 ]
 
 { #category : #'private - accessing' }
-ResourceRESTfulController >> entityTagOf: resource encodedAs: mediaType [
+ResourceRESTfulController >> entityTagOf: resource encodedAs: mediaType within: aContext [
 
 	self subclassResponsibility
 ]
@@ -104,21 +104,28 @@ ResourceRESTfulController >> get: aQueryEvaluationBlock encodedUsing: aKey based
 			self
 				ifNoneMatchHeaderPresentIn: anHttpRequest
 				do: [ :etag | 
-					etag = (self entityTagOf: resource encodedAs: mediaType)
+					etag = ( self entityTagOf: resource encodedAs: mediaType within: aContext )
 						ifTrue: [ ^ ZnResponse notModified
 								setEntityTag: etag;
-								yourself ] ].
+								yourself
+							]
+					].
 
 			self hypermediaPolicy holdResource: resource controlsWithin: aContext.
 			response := ZnResponse
 				ok:
-					(self
+					( self
 						encode: resource
 						at: aKey
 						to: mediaType
-						within: aContext).
-			self putEntityTagOf: resource encodedAs: mediaType in: response.
-			response ]
+						within: aContext ).
+			self
+				putEntityTagOf: resource
+				encodedAs: mediaType
+				in: response
+				within: aContext.
+			response
+			]
 ]
 
 { #category : #'private - transformations' }
@@ -152,15 +159,15 @@ ResourceRESTfulController >> initialize [
 ]
 
 { #category : #'private - accessing' }
-ResourceRESTfulController >> locationOf: resource [
+ResourceRESTfulController >> locationOf: resource within: aContext [
 
 	self subclassResponsibility
 ]
 
 { #category : #'private - accessing' }
-ResourceRESTfulController >> mediaControlsFor: result [
+ResourceRESTfulController >> mediaControlsFor: result within: aContext [
 
-	^ {'self' -> (self locationOf: result)}
+	^ {( 'self' -> ( self locationOf: result within: aContext ) )}
 ]
 
 { #category : #'private - accessing' }
@@ -189,9 +196,9 @@ ResourceRESTfulController >> provideResourceCreationPolicy [
 ]
 
 { #category : #'private - API' }
-ResourceRESTfulController >> putEntityTagOf: resource encodedAs: mediaType in: response [
+ResourceRESTfulController >> putEntityTagOf: resource encodedAs: mediaType in: response within: aContext [
 
-	response setEntityTag: (self entityTagOf: resource encodedAs: mediaType)
+	response setEntityTag: ( self entityTagOf: resource encodedAs: mediaType within: aContext )
 ]
 
 { #category : #'private - accessing' }

--- a/source/Stargate-Model/ZnUrl.extension.st
+++ b/source/Stargate-Model/ZnUrl.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #ZnUrl }
+
+{ #category : #'*Stargate-Model' }
+ZnUrl >> queryAt: aKey putUrl: anUnencodedUrl [
+
+	| encodedUrl |
+
+	encodedUrl := anUnencodedUrl urlEncoded.
+	^ self queryAt: aKey put: encodedUrl
+]
+
+{ #category : #'*Stargate-Model' }
+ZnUrl >> start: startIndex limit: limitCount [
+
+	self
+		queryAt: 'start' put: startIndex;
+		queryAt: 'limit' put: limitCount
+]


### PR DESCRIPTION
Backport improvements made at @Mercap during May:

- Add `context` to the methods resolving the ETag, Location and Media Controls, because in some complex cases it's needed to pass additional information.
- Consistency renames
- Respond with Bad Request when the pagination cannot be correctly created from the parameters
- Include "ETag" header when a POST request is responded including a representation
-  Add some utilities to ZnUrl for pagination and query parameters including URLs
- Add some utility methods to ResourceRESTfulControllerTest improving PATCH usage