### PR TITLE
Move ResourceRESTfulControllerTest to it's own package

### DIFF
--- a/source/BaselineOfStargate/BaselineOfStargate.class.st
+++ b/source/BaselineOfStargate/BaselineOfStargate.class.st
@@ -12,31 +12,13 @@ BaselineOfStargate >> baseline: spec [
 		for: #pharo
 		do: [ self
 				setUpDependencies: spec;
-				baselineStargate: spec.
+				setUpPackages: spec.
 			spec
 				group: 'CI' with: 'Tests';
 				group: 'Examples' with: #('Deployment' 'Stargate-Examples');
 				group: 'Tools' with: #('Buoy-Tools' 'Teapot-Tools');
 				group: 'Development' with: #('Tests' 'Tools')
 			]
-]
-
-{ #category : #baselines }
-BaselineOfStargate >> baselineStargate: spec [
-
-	spec
-		package: 'Stargate-Model' with: [ spec requires: #('Buoy-Deployment' 'Teapot-Deployment') ];
-		group: 'Deployment' with: 'Stargate-Model'.
-	spec
-		package: 'Stargate-Examples' with: [ spec requires: 'Stargate-Model' ];
-		group: 'Examples' with: 'Stargate-Examples'.
-	spec
-		package: 'Stargate-Model-Tests' with: [ spec requires: #('Stargate-Model' 'Stargate-Examples') ];
-		group: 'Tests' with: 'Stargate-Model-Tests'.
-	spec
-		package: 'Stargate-Examples-Tests'
-			with: [ spec requires: #('Stargate-Model-Tests' 'Stargate-Examples') ];
-		group: 'Tests' with: 'Stargate-Examples-Tests'
 ]
 
 { #category : #accessing }
@@ -58,4 +40,25 @@ BaselineOfStargate >> setUpDependencies: spec [
 		baseline: 'Teapot' with: [ spec repository: 'github://zeroflag/Teapot:v2.6.0/source' ];
 		project: 'Teapot-Deployment' copyFrom: 'Teapot' with: [ spec loads: 'Deployment' ];
 		project: 'Teapot-Tools' copyFrom: 'Teapot' with: [ spec loads: 'Tools' ]
+]
+
+{ #category : #baselines }
+BaselineOfStargate >> setUpPackages: spec [
+
+	spec
+		package: 'Stargate-Model' with: [ spec requires: #('Buoy-Deployment' 'Teapot-Deployment') ];
+		group: 'Deployment' with: 'Stargate-Model'.
+	spec
+		package: 'Stargate-Examples' with: [ spec requires: 'Stargate-Model' ];
+		group: 'Examples' with: 'Stargate-Examples'.
+	spec
+		package: 'Stargate-SUnit-Model' with: [ spec requires: #('Stargate-Model' 'Buoy-SUnit') ];
+		group: 'Dependent-SUnit-Extensions' with: 'Stargate-SUnit-Model'.
+	spec
+		package: 'Stargate-Model-Tests' with: [ spec requires: #('Stargate-Model' 'Stargate-Examples') ];
+		group: 'Tests' with: 'Stargate-Model-Tests'.
+	spec
+		package: 'Stargate-Examples-Tests'
+			with: [ spec requires: #('Dependent-SUnit-Extensions' 'Stargate-Examples') ];
+		group: 'Tests' with: 'Stargate-Examples-Tests'
 ]

--- a/source/Stargate-SUnit-Model/ResourceRESTfulControllerTest.class.st
+++ b/source/Stargate-SUnit-Model/ResourceRESTfulControllerTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'resourceController'
 	],
-	#category : #'Stargate-Model-Tests-Controllers'
+	#category : #'Stargate-SUnit-Model'
 }
 
 { #category : #testing }

--- a/source/Stargate-SUnit-Model/package.st
+++ b/source/Stargate-SUnit-Model/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Stargate-SUnit-Model' }


### PR DESCRIPTION
and include `Dependent-SUnit-Extensions` group in the baseline.

Fixes #28