### PR TITLE
Add a new Operational Plugin: Application Configuration

### DIFF
--- a/docs/ApplicationConfiguration.md
+++ b/docs/ApplicationConfiguration.md
@@ -1,0 +1,66 @@
+# Application Configuration
+
+One of the operational plugins. It exposes information about the configuration of the running application.
+
+This plugin is disabled by default and allows configuring the available configuration providers. This configuration is made via the `#operations` config.
+
+For example:
+
+```smalltalk
+Dictionary new
+  at: #operations put: (
+    Dictionary new
+      at: 'application-configuration'
+      put: {#enabled -> true. #'definitions' -> application definitions. #provider -> application configuration } asDictionary;
+      yourself
+    );
+  yourself
+```
+
+## API
+
+### Getting configuration information
+
+- Endpoint: `/application-configuration`
+- Allowed HTTP methods: `GET`
+- Supported media types:
+  - `application/vnd.stargate.operational-application-configuration+json`
+  - `text/plain`
+- Authentication: Required
+- Authorization: Requires `read:application-configuration`
+- Expected Responses:
+  - `200 OK`
+
+Example response:
+
+```json
+HTTP/1.1 200 OK
+...
+[
+  {
+    "type": "optional",
+    "name": "port",
+    "current-value": 6000,
+    "default": 4000
+  },
+  {
+    "type": "mandatory",
+    "name": "base-url",
+    "current-value": "https://api.example.com"
+  },
+  {
+    "type": "flag",
+    "name": "debug-mode",
+    "current-value": true
+  }
+]
+```
+
+```
+HTTP/1.1 200 OK
+...
+
+port = 6000
+base-url = https://api.example.com
+debug-mode = true
+```

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -10,6 +10,7 @@ An operational plugin has the following characteristics:
 - Should be possible to enable/disable/configure it on the fly using an API endpoint (given the proper authorization credentials) using the media controls provided in the plugin representation
 
 ## Implemented Plugins
+- [Application Configuration](ApplicationConfiguration.md)
 - [Application Control](ApplicationControl.md)
 - [Application Info](ApplicationInfo.md)
 - [Healt Check](HealthCheck.md)

--- a/source/BaselineOfStargate/BaselineOfStargate.class.st
+++ b/source/BaselineOfStargate/BaselineOfStargate.class.st
@@ -65,7 +65,14 @@ BaselineOfStargate >> setUpDependencies: spec [
 
 	spec
 		baseline: 'JRPC' with: [ spec repository: 'github://juliendelplanque/JRPC:v3.0.0/src' ];
-		project: 'JRPC-Deployment' copyFrom: 'JRPC' with: [ spec loads: 'Server-Deployment' ]
+		project: 'JRPC-Deployment' copyFrom: 'JRPC' with: [ spec loads: 'Server-Deployment' ].
+
+	spec
+		baseline: 'ApplicationStarter'
+			with: [ spec repository: 'github://ba-st/ApplicationStarter:v1/source' ];
+		project: 'ApplicationStarter-Deployment'
+			copyFrom: 'ApplicationStarter'
+			with: [ spec loads: 'Deployment' ]
 ]
 
 { #category : #baselines }
@@ -107,7 +114,13 @@ BaselineOfStargate >> setUpDeploymentPackages: spec [
 	spec
 		package: 'Stargate-Application-Info' with: [ spec requires: 'Stargate-Model' ];
 		group: 'Application-Info' with: 'Stargate-Application-Info';
-		group: 'Deployment' with: 'Application-Info'
+		group: 'Deployment' with: 'Application-Info'.
+
+	spec
+		package: 'Stargate-Application-Configuration'
+			with: [ spec requires: #('Stargate-Model' 'ApplicationStarter-Deployment') ];
+		group: 'Application-Configuration' with: 'Stargate-Application-Configuration';
+		group: 'Deployment' with: 'Application-Configuration'
 ]
 
 { #category : #baselines }
@@ -150,6 +163,10 @@ BaselineOfStargate >> setUpTestPackages: spec [
 		package: 'Stargate-Application-Info-Tests'
 			with: [ spec requires: #('Application-Info' 'Stargate-Model-Tests') ];
 		group: 'Tests' with: 'Stargate-Application-Info-Tests'.
+	spec
+		package: 'Stargate-Application-Configuration-Tests'
+			with: [ spec requires: #('Application-Configuration' 'Stargate-Model-Tests') ];
+		group: 'Tests' with: 'Stargate-Application-Configuration-Tests'.
 	spec
 		package: 'Stargate-Examples-Tests'
 			with: [ spec requires: #('Dependent-SUnit-Extensions' 'Stargate-Examples') ];

--- a/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginAPITest.class.st
+++ b/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginAPITest.class.st
@@ -1,0 +1,69 @@
+"
+I'm the test case for the Application Configuration API
+"
+Class {
+	#name : #ApplicationConfigurationPluginAPITest,
+	#superclass : #OperationalPluginAPITest,
+	#category : #'Stargate-Application-Configuration-Tests'
+}
+
+{ #category : #private }
+ApplicationConfigurationPluginAPITest >> configurationDefinitions [
+
+	^ Array with: ( FlagArgument named: 'debug-mode' )
+]
+
+{ #category : #private }
+ApplicationConfigurationPluginAPITest >> configurationProvider [
+
+	^ [ Dictionary new
+		at: 'debug-mode' put: true;
+		yourself
+	]
+]
+
+{ #category : #running }
+ApplicationConfigurationPluginAPITest >> operationsConfiguration [
+
+	^ super operationsConfiguration
+		at: ApplicationConfigurationPlugin endpoint
+		put: {
+				#enabled -> true .
+				#definitions -> self configurationDefinitions .
+				#provider -> self configurationProvider 
+				} asDictionary;
+		yourself
+]
+
+{ #category : #private }
+ApplicationConfigurationPluginAPITest >> requiredPermissions [
+
+	^ #('read:application-configuration')
+]
+
+{ #category : #tests }
+ApplicationConfigurationPluginAPITest >> testGetConfigurationWithPermissions [
+
+	| response |
+
+	response := self newJWTAuthorizedClient
+		url: self operationsUrl / ApplicationConfigurationPlugin endpoint asUrl;
+		setAccept: ZnMimeType applicationJson;
+		get;
+		response.
+
+	self
+		assert: response isSuccess;
+		assert: response contentType asMediaType
+			equals: 'application/vnd.stargate.operational-application-configuration+json;version=1.0.0' asMediaType;
+		withJsonFromContentsIn: response
+			do: [ :configurations | 
+			self
+				withTheOnlyOneIn: configurations
+				do: [ :config | 
+					self
+						assert: config name equals: 'debug-mode';
+						assert: ( config at: #'current-value' )
+					]
+			]
+]

--- a/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginConfigurationAPITest.class.st
+++ b/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginConfigurationAPITest.class.st
@@ -1,0 +1,36 @@
+"
+I'm a test for API configuration options
+"
+Class {
+	#name : #ApplicationConfigurationPluginConfigurationAPITest,
+	#superclass : #OperationalPluginAPITest,
+	#category : #'Stargate-Application-Configuration-Tests'
+}
+
+{ #category : #running }
+ApplicationConfigurationPluginConfigurationAPITest >> operationsConfiguration [
+
+	^ super operationsConfiguration
+		at: ApplicationConfigurationPlugin endpoint put: { #enabled -> false } asDictionary;
+		yourself
+]
+
+{ #category : #private }
+ApplicationConfigurationPluginConfigurationAPITest >> requiredPermissions [
+
+	^ #('read:application-configuration')
+]
+
+{ #category : #tests }
+ApplicationConfigurationPluginConfigurationAPITest >> testPluginIsDisabled [
+
+	self
+		deny: ( api isEnabled: ApplicationConfigurationPlugin );
+		should: [ self newJWTAuthorizedClient
+				url: self operationsUrl / ApplicationConfigurationPlugin endpoint asUrl;
+				setAccept: ZnMimeType textPlain;
+				get
+			]
+			raise: ZnHttpUnsuccessful
+			withExceptionDo: [ :error | self assert: error response isNotFound ]
+]

--- a/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginTest.class.st
+++ b/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginTest.class.st
@@ -1,0 +1,88 @@
+"
+An ApplicationConfigurationPluginTest is a test class for testing the behavior of ApplicationConfigurationPlugin
+"
+Class {
+	#name : #ApplicationConfigurationPluginTest,
+	#superclass : #TestCase,
+	#category : #'Stargate-Application-Configuration-Tests'
+}
+
+{ #category : #accessing }
+ApplicationConfigurationPluginTest >> configuration [
+
+	^ Dictionary new
+		at: ApplicationConfigurationPlugin endpoint
+			put: {
+				#enabled -> true .
+				#definitions -> self configurationDefinitions .
+				#provider -> self configurationProvider 
+				} asDictionary;
+		yourself
+]
+
+{ #category : #accessing }
+ApplicationConfigurationPluginTest >> configurationDefinitions [
+
+	^ Array
+		with: ( OptionalArgument named: 'port' defaultingTo: 4000 )
+		with: ( MandatoryArgument named: 'base-url' )
+		with: ( FlagArgument named: 'debug-mode' )
+]
+
+{ #category : #accessing }
+ApplicationConfigurationPluginTest >> configurationProvider [
+
+	^ [ Dictionary new
+		at: 'port' put: 6000;
+		at: 'base-url' put: 'https://api.example.com';
+		at: 'debug-mode' put: true;
+		yourself
+	]
+]
+
+{ #category : #tests }
+ApplicationConfigurationPluginTest >> testConfigurationAccessing [
+
+	| plugin definition |
+
+	plugin := ApplicationConfigurationPlugin configuredBy: self configuration.
+
+	self assert: plugin configurationDefinitions size equals: 3.
+
+	definition := plugin configurationDefinitions first.
+
+	self
+		assert: definition name equals: 'port';
+		assert: definition default equals: 4000;
+		assert: ( plugin currentValueFor: definition ) equals: 6000.
+
+	definition := plugin configurationDefinitions second.
+
+	self
+		assert: definition name equals: 'base-url';
+		assert: ( plugin currentValueFor: definition ) equals: 'https://api.example.com'.
+
+	definition := plugin configurationDefinitions last.
+
+	self
+		assert: definition name equals: 'debug-mode';
+		assert: ( plugin currentValueFor: definition )
+]
+
+{ #category : #tests }
+ApplicationConfigurationPluginTest >> testEnabledByDefault [
+
+	self deny: ApplicationConfigurationPlugin enabledByDefault
+]
+
+{ #category : #tests }
+ApplicationConfigurationPluginTest >> testEndpoint [
+
+	self assert: ApplicationConfigurationPlugin endpoint equals: 'application-configuration'
+]
+
+{ #category : #tests }
+ApplicationConfigurationPluginTest >> testPluginName [
+
+	self assert: ApplicationConfigurationPlugin pluginName equals: 'Application Configuration'
+]

--- a/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationRESTfulControllerTest.class.st
+++ b/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationRESTfulControllerTest.class.st
@@ -94,7 +94,10 @@ ApplicationConfigurationRESTfulControllerTest >> testGetConfigurationInPlainText
 		assert: response isSuccess;
 		assert: response contentType asMediaType equals: ( ZnMimeType textPlain version: '1.0.0' );
 		assert: response contents
-			equals: 'port = 6000<r><l>base-url = https://api.example.com<r><l>debug-mode = true' expandMacros
+			equals:
+			( 'port = 6000<1s><2s>base-url = https://api.example.com<1s><2s>debug-mode = true'
+				expandMacrosWith: String cr
+				with: String lf )
 ]
 
 { #category : #'private - support' }

--- a/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationRESTfulControllerTest.class.st
+++ b/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationRESTfulControllerTest.class.st
@@ -1,0 +1,104 @@
+"
+An ApplicationConfigurationRESTfulControllerTest is a test class for testing the behavior of ApplicationConfigurationRESTfulController
+"
+Class {
+	#name : #ApplicationConfigurationRESTfulControllerTest,
+	#superclass : #OperationalPluginRESTfulControllerTest,
+	#category : #'Stargate-Application-Configuration-Tests'
+}
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> configurationDefinitions [
+
+	^ Array
+		with: ( OptionalArgument named: 'port' defaultingTo: 4000 )
+		with: ( MandatoryArgument named: 'base-url' )
+		with: ( FlagArgument named: 'debug-mode' )
+]
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> configurationProvider [
+
+	^ [ Dictionary new
+		at: 'port' put: 6000;
+		at: 'base-url' put: 'https://api.example.com';
+		at: 'debug-mode' put: true;
+		yourself
+	]
+]
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> operationsConfiguration [
+
+	^ super operationsConfiguration
+		at: ApplicationConfigurationPlugin endpoint
+		put: {
+				#enabled -> true .
+				#definitions -> self configurationDefinitions .
+				#provider -> self configurationProvider 
+				} asDictionary;
+		yourself
+]
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> setUpResourceController [
+
+	resourceController := ApplicationConfigurationRESTfulController
+		over: ( ApplicationConfigurationPlugin configuredBy: self operationsConfiguration )
+		configuredBy: self operationsConfiguration
+]
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> testGetConfigurationInJson [
+
+	| response |
+
+	response := resourceController
+		getApplicationConfigurationBasedOn: ( self requestToGET: self resourceUrl accepting: ZnMimeType applicationJson )
+		within: self newHttpRequestContext.
+
+	self
+		assert: response isSuccess;
+		assert: response contentType asMediaType
+			equals: resourceController operationalApplicationConfigurationVersion1dot0dot0MediaType;
+		withJsonFromContentsIn: response
+			do: [ :configs | 
+			self
+				assert: configs size equals: 3;
+				withConfigurationNamed: 'port'
+					in: configs
+					do: [ :config | 
+					self
+						assert: ( config at: #'current-value' ) equals: 6000;
+						assert: config default equals: 4000
+					];
+				withConfigurationNamed: 'base-url'
+					in: configs
+					do: [ :config | self assert: ( config at: #'current-value' ) equals: 'https://api.example.com' ];
+				withConfigurationNamed: 'debug-mode'
+					in: configs
+					do: [ :config | self assert: ( config at: #'current-value' ) ]
+			]
+]
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> testGetConfigurationInPlainText [
+
+	| response |
+
+	response := resourceController
+		getApplicationConfigurationBasedOn: ( self requestToGET: self resourceUrl accepting: ZnMimeType textPlain )
+		within: self newHttpRequestContext.
+
+	self
+		assert: response isSuccess;
+		assert: response contentType asMediaType equals: ( ZnMimeType textPlain version: '1.0.0' );
+		assert: response contents
+			equals: 'port = 6000<r><l>base-url = https://api.example.com<r><l>debug-mode = true' expandMacros
+]
+
+{ #category : #'private - support' }
+ApplicationConfigurationRESTfulControllerTest >> withConfigurationNamed: aName in: configurations do: aBlock [
+
+	configurations detect: [ :config | config name = aName ] ifFound: aBlock ifNone: [ self fail ]
+]

--- a/source/Stargate-Application-Configuration-Tests/package.st
+++ b/source/Stargate-Application-Configuration-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Stargate-Application-Configuration-Tests' }

--- a/source/Stargate-Application-Configuration/ApplicationConfigurationPlugin.class.st
+++ b/source/Stargate-Application-Configuration/ApplicationConfigurationPlugin.class.st
@@ -1,0 +1,71 @@
+"
+I'm one of the operational plugins.
+I provide information about the configuration of the running system.
+"
+Class {
+	#name : #ApplicationConfigurationPlugin,
+	#superclass : #OperationalPlugin,
+	#instVars : [
+		'valueProvider',
+		'configurationDefinitions'
+	],
+	#category : #'Stargate-Application-Configuration'
+}
+
+{ #category : #configuring }
+ApplicationConfigurationPlugin class >> configureMediaControlsIn: builder within: requestContext [
+
+	builder
+		addRelativeLink: ( 'operations/<1s>' expandMacrosWith: self endpoint ) asUrl
+		relatedTo: 'configuration'
+]
+
+{ #category : #'instance creation' }
+ApplicationConfigurationPlugin class >> configuredBy: configuration [
+
+	| selfConfiguration |
+
+	selfConfiguration := self pluginConfigurationOn: configuration.
+
+	^ self new
+		initializeDefinedBy: ( selfConfiguration at: #definitions ifAbsent: [ #() ] )
+		querying: ( selfConfiguration at: #provider ifAbsent: [ [ Dictionary new ] ] )
+]
+
+{ #category : #accessing }
+ApplicationConfigurationPlugin class >> endpoint [
+
+	^ 'application-configuration'
+]
+
+{ #category : #accessing }
+ApplicationConfigurationPlugin class >> pluginName [
+
+	^ 'Application Configuration'
+]
+
+{ #category : #accessing }
+ApplicationConfigurationPlugin >> configurationDefinitions [
+
+	^ configurationDefinitions
+]
+
+{ #category : #accessing }
+ApplicationConfigurationPlugin >> currentValueFor: aDefinition [
+
+	^ valueProvider value at: aDefinition name 
+]
+
+{ #category : #configuring }
+ApplicationConfigurationPlugin >> includeControllersIn: api [
+
+	api
+		addController: ( ApplicationConfigurationRESTfulController over: self configuredBy: api operationsConfiguration )
+]
+
+{ #category : #initialization }
+ApplicationConfigurationPlugin >> initializeDefinedBy: configurationDefinition querying: aConfigurationProvider [
+
+	configurationDefinitions := configurationDefinition.
+	valueProvider := aConfigurationProvider
+]

--- a/source/Stargate-Application-Configuration/ApplicationConfigurationRESTfulController.class.st
+++ b/source/Stargate-Application-Configuration/ApplicationConfigurationRESTfulController.class.st
@@ -1,0 +1,138 @@
+"
+I'm a controller exposing the API of ApplicationInfoPlugin
+"
+Class {
+	#name : #ApplicationConfigurationRESTfulController,
+	#superclass : #OperationsRESTfulController,
+	#instVars : [
+		'requestHandler',
+		'plugin'
+	],
+	#category : #'Stargate-Application-Configuration'
+}
+
+{ #category : #'instance creation' }
+ApplicationConfigurationRESTfulController class >> over: aPlugin configuredBy: configuration [
+
+	^ ( self authenticationFilterBasedOn: configuration ) initializeOver: aPlugin
+]
+
+{ #category : #private }
+ApplicationConfigurationRESTfulController >> configureConfigurationEncodingOn: writer [
+
+	writer
+		for: MandatoryArgument
+			do: [ :mapper | 
+			mapper
+				mapProperty: #type getter: [ :definition | 'mandatory' ];
+				mapAccessor: #name;
+				mapProperty: #'current-value' getter: [ :definition | plugin currentValueFor: definition ]
+			];
+		for: FlagArgument
+			do: [ :mapper | 
+			mapper
+				mapProperty: #type getter: [ :definition | 'flag' ];
+				mapAccessor: #name;
+				mapProperty: #'current-value' getter: [ :definition | plugin currentValueFor: definition ]
+			];
+		for: OptionalArgument
+			do: [ :mapper | 
+			mapper
+				mapProperty: #type getter: [ :definition | 'optional' ];
+				mapAccessor: #name;
+				mapProperty: #'current-value' getter: [ :definition | plugin currentValueFor: definition ];
+				mapAccessor: #default
+			]
+]
+
+{ #category : #routes }
+ApplicationConfigurationRESTfulController >> declareGetApplicationConfigurationRoute [
+
+	^ RouteSpecification
+		handling: #GET
+		at: self endpoint
+		evaluating:
+			[ :httpRequest :requestContext | self getApplicationConfigurationBasedOn: httpRequest within: requestContext ]
+]
+
+{ #category : #initialization }
+ApplicationConfigurationRESTfulController >> encodeConfigurationInTextFormat: configurationDefinitions [
+
+	^ String
+		streamContents: [ :stream | 
+			configurationDefinitions
+				do: [ :definition | 
+					stream
+						nextPutAll: definition name;
+						space;
+						nextPut: $=;
+						space;
+						nextPutAll: ( plugin currentValueFor: definition ) asString
+					]
+				separatedBy: [ stream crlf ]
+			]
+]
+
+{ #category : #API }
+ApplicationConfigurationRESTfulController >> getApplicationConfigurationBasedOn: httpRequest within: requestContext [
+
+	self assert: httpRequest isAuthorizedWithin: requestContext.
+
+	^ requestHandler
+		from: httpRequest
+		within: requestContext
+		getCollection: [ plugin configurationDefinitions ]
+]
+
+{ #category : #initialization }
+ApplicationConfigurationRESTfulController >> initializeOver: aPlugin [
+
+	plugin := aPlugin.
+	self initializeRequestHandler
+]
+
+{ #category : #initialization }
+ApplicationConfigurationRESTfulController >> initializeRequestHandler [
+
+	requestHandler := RESTfulRequestHandlerBuilder new
+		handling: ( 'operations/<1s>' expandMacrosWith: self pluginEndpoint );
+		whenResponding: self operationalApplicationConfigurationVersion1dot0dot0MediaType
+			encodeToJsonApplying: [ :resource :requestContext :writer | self configureConfigurationEncodingOn: writer ];
+		whenResponding: self plainTextVersion1dot0dot0MediaType
+			encodeApplying: [ :resource | self encodeConfigurationInTextFormat: resource ];
+		createEntityTagHashingEncodedResource;
+		build
+]
+
+{ #category : #private }
+ApplicationConfigurationRESTfulController >> operationalApplicationConfigurationVersion1dot0dot0MediaType [
+
+	^ self
+		jsonMediaType: 'operational-application-configuration'
+		vendoredBy: 'stargate'
+		version: '1.0.0'
+]
+
+{ #category : #private }
+ApplicationConfigurationRESTfulController >> plainTextVersion1dot0dot0MediaType [
+
+	^ ZnMimeType textPlain version: '1.0.0'
+]
+
+{ #category : #private }
+ApplicationConfigurationRESTfulController >> pluginEndpoint [
+
+	^ plugin class endpoint
+]
+
+{ #category : #private }
+ApplicationConfigurationRESTfulController >> requestHandler [
+
+	^ requestHandler
+]
+
+{ #category : #private }
+ApplicationConfigurationRESTfulController >> requiredPermission [
+
+	^ 'read:<1s>' expandMacrosWith: self pluginEndpoint
+]

--- a/source/Stargate-Application-Configuration/package.st
+++ b/source/Stargate-Application-Configuration/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Stargate-Application-Configuration' }

--- a/source/Stargate-Model-Tests/OperationalPluginsRESTfulControllerTest.class.st
+++ b/source/Stargate-Model-Tests/OperationalPluginsRESTfulControllerTest.class.st
@@ -8,6 +8,20 @@ Class {
 }
 
 { #category : #'private - asserting' }
+OperationalPluginsRESTfulControllerTest >> assertApplicationConfigurationStatusOn: plugins [
+
+	^ plugins
+		detect: [ :plugin | plugin name = ApplicationConfigurationPlugin pluginName ]
+		ifFound: [ :applicationControl | 
+			self
+				assert: applicationControl status equals: 'DISABLED';
+				assertUrl: applicationControl selfLocation
+					equals: 'https://api.example.com/operations/plugins/application-configuration'
+			]
+		ifNone: [ self fail ]
+]
+
+{ #category : #'private - asserting' }
 OperationalPluginsRESTfulControllerTest >> assertApplicationControlStatusOn: plugins [
 
 	^ plugins
@@ -123,11 +137,12 @@ OperationalPluginsRESTfulControllerTest >> testGetPlugins [
 	self
 		withJsonFromItemsIn: response
 		do: [ :plugins | 
-			self assert: plugins size equals: 4.
+			self assert: plugins size equals: 5.
 			self
 				assertHealthcheckStatusOn: plugins;
 				assertMetricsStatusOn: plugins;
 				assertApplicationControlStatusOn: plugins;
-				assertApplicationInfoStatusOn: plugins
+				assertApplicationInfoStatusOn: plugins;
+				assertApplicationConfigurationStatusOn: plugins
 			]
 ]


### PR DESCRIPTION
This changes make available a new operational plugin. This plugin is disabled by default and must be explicitely enabled in the API configuration. 
The API implementor must also provide two other configuration parameters:
* `#definitions` : including a list of configuration definitions
* `#provider` : a valuable that will provide the current application configuration, this configuration must be queryable by definition name to get
the current value.

Two output formats are implemented:
* Plain Text
* Vendored Json

(See the upcoming documentation for more details)

Fixes #42