### PR TITLE
Fix Application Configuration Plugin to allow URLs

### DIFF
--- a/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginAPITest.class.st
+++ b/source/Stargate-Application-Configuration-Tests/ApplicationConfigurationPluginAPITest.class.st
@@ -10,14 +10,14 @@ Class {
 { #category : #private }
 ApplicationConfigurationPluginAPITest >> configurationDefinitions [
 
-	^ Array with: ( FlagArgument named: 'debug-mode' )
+	^ Array with: ( MandatoryArgument named: 'public-url' )
 ]
 
 { #category : #private }
 ApplicationConfigurationPluginAPITest >> configurationProvider [
 
 	^ [ Dictionary new
-		at: 'debug-mode' put: true;
+		at: 'public-url' put: 'http://api.example.com' asUrl;
 		yourself
 	]
 ]
@@ -62,8 +62,8 @@ ApplicationConfigurationPluginAPITest >> testGetConfigurationWithPermissions [
 				withTheOnlyOneIn: configurations
 				do: [ :config | 
 					self
-						assert: config name equals: 'debug-mode';
-						assert: ( config at: #'current-value' )
+						assert: config name equals: 'public-url';
+						assert: ( config at: #'current-value' ) equals: 'http://api.example.com/'
 					]
 			]
 ]

--- a/source/Stargate-Application-Configuration/ApplicationConfigurationRESTfulController.class.st
+++ b/source/Stargate-Application-Configuration/ApplicationConfigurationRESTfulController.class.st
@@ -42,7 +42,8 @@ ApplicationConfigurationRESTfulController >> configureConfigurationEncodingOn: w
 				mapAccessor: #name;
 				mapProperty: #'current-value' getter: [ :definition | plugin currentValueFor: definition ];
 				mapAccessor: #default
-			]
+			];
+		for: ZnUrl customDo: [ :mapping | mapping encoder: [ :url | url printString ] ]
 ]
 
 { #category : #routes }


### PR DESCRIPTION
Now instances of ZnUrl can be used in the configuration and correctly encoded to JSON.