### PR TITLE
Add configuration via block in http support requestToGET

### DIFF
--- a/source/Stargate-Examples-Tests/PetsRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/PetsRESTfulControllerTest.class.st
@@ -137,6 +137,34 @@ PetsRESTfulControllerTest >> testCantDeleteInvalidPet [
 		withExceptionDo: [ :signal | self assert: signal code equals: 404 ]
 ]
 
+{ #category : #'tests - get individual' }
+PetsRESTfulControllerTest >> testCantGetPetSpecifyingLanguageRange [
+
+	self
+		assert: ( resourceController
+				  createPetBasedOn: ( self requestToCreatePetFrom: '{"name":"Firulais","type":"dog"}' )
+				  within: self newHttpRequestContext ) isSuccess;
+		assert: petRepository count equals: 1.
+
+	self
+		should: [ 
+			resourceController
+				getPetBasedOn: ( self
+						  requestToGETResourceIdentifiedBy: 1
+						  acceptingContentMatching: self defaultPetMediaType
+						  inAnyOf: '*' )
+				within: self newHttpRequestContext
+			]
+		raise: HTTPNotAcceptable
+		withExceptionDo: [ :error | 
+			self
+				assert: error messageText
+				equals: 'Cannot generate a response entity with acceptable characteristics.';
+				assert: error code equals: 406;
+				assert: error allowedLanguageTags isEmpty
+			]
+]
+
 { #category : #'tests - update' }
 PetsRESTfulControllerTest >> testCantUpdatePetIfMissingETag [
 

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -19,10 +19,22 @@ SouthAmericanCurrenciesRESTfulControllerTest >> baseUrl [
 	^ 'https://currencies.example.com' asUrl
 ]
 
+{ #category : #'private - support' }
+SouthAmericanCurrenciesRESTfulControllerTest >> english [
+
+	^ 'en'
+]
+
 { #category : #running }
 SouthAmericanCurrenciesRESTfulControllerTest >> setUpResourceController [
 
 	resourceController := SouthAmericanCurrenciesRESTfulController new
+]
+
+{ #category : #'private - support' }
+SouthAmericanCurrenciesRESTfulControllerTest >> spanish [
+
+	^ 'es'
 ]
 
 { #category : #tests }
@@ -34,7 +46,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 	           requestToGETResourceIdentifiedBy: 'ARS'
 	           acceptingContentMatching:
 	           resourceController currencyVersion1dot0dot0MediaType
-	           and: ''.
+	           inAnyOf: ''.
 
 	self
 		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
@@ -53,26 +65,30 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingForUnsupportedLanguage [
 
-	| request |
+	| request unsupportedLanguage |
+	unsupportedLanguage := 'de'.
 
 	request := self
-	           requestToGETResourceIdentifiedBy: 'ARS'
-	           acceptingContentMatching:
-	           resourceController currencyVersion1dot0dot0MediaType
-	           and: 'de'.
+		           requestToGETResourceIdentifiedBy: 'ARS'
+		           acceptingContentMatching:
+		           resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: unsupportedLanguage.
 
 	self
-		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
+		should: [ 
+			resourceController
+				currencyBasedOn: request
+				within: self newHttpRequestContext ]
 		raise: HTTPNotAcceptable
 		withExceptionDo: [ :error | 
 			self
 				assert: error messageText
-					equals: 'Cannot generate a response entity with acceptable characteristics.';
+				equals:
+					'Cannot generate a response entity with acceptable characteristics.';
 				assert: error code equals: 406;
 				assert: error allowedLanguageTags size equals: 2;
 				assert: error allowedLanguageTags includes: 'en-US' asLanguageTag;
-				assert: error allowedLanguageTags includes: 'es-AR' asLanguageTag
-			]
+				assert: error allowedLanguageTags includes: 'es-AR' asLanguageTag ]
 ]
 
 { #category : #tests }
@@ -135,11 +151,12 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoBanknotes [
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglish [
 
 	| response request |
+	
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
 		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 and: 'en'.
+		           inAnyOf: self english.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -173,7 +190,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglishBas
 		           requestToGETResourceIdentifiedBy: 'ARS'
 		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 and: '*'.
+						 inAnyOf: '*'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -203,11 +220,12 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglishBas
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 
 	| response request |
+	
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
 		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 and: 'es'.
+		           inAnyOf: self spanish.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -234,14 +252,15 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 ]
 
 { #category : #tests }
-SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanishBasedOnLanguageQualityPriority [
+SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanishBasedOnLanguagePriorityList [
 
-	| response request |
+	| response request languagePriorityList |
+	languagePriorityList := 'de,en;q=0.5,es;=0.6'.
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
 		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 and: 'de,en;q=0.5,es;=0.6'.
+		           inAnyOf: languagePriorityList.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -305,7 +324,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInEnglish [
 		           requestToGETResourceIdentifiedBy: 'BRL'
 		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 and: 'en'.
+						 inAnyOf: self english.
 	
 
 	response := resourceController
@@ -340,7 +359,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInSpanish [
 		           requestToGETResourceIdentifiedBy: 'BRL'
 		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 and: 'es' asLanguageTag.
+						 inAnyOf: self spanish.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -409,7 +428,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrenciesInSpanish [
 			requestConfig
 				setAccept:
 					resourceController currencyVersion1dot0dot0MediaType;
-				setAcceptLanguage: 'es' ].
+				setAcceptLanguage: self spanish ].
 
 	response := resourceController currenciesBasedOn: request within: self newHttpRequestContext.
 

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -26,6 +26,31 @@ SouthAmericanCurrenciesRESTfulControllerTest >> setUpResourceController [
 ]
 
 { #category : #tests }
+SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingForAnEmptyLanguage [
+
+	| request |
+
+	request := self
+	           requestToGETResourceIdentifiedBy: 'ARS'
+	           representedAs:
+	           resourceController currencyVersion1dot0dot0MediaType
+	           in: ''.
+
+	self
+		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
+		raise: HTTPNotAcceptable
+		withExceptionDo: [ :error | 
+			self
+				assert: error messageText
+					equals: 'Cannot generate a response entity with acceptable characteristics.';
+				assert: error code equals: 406;
+				assert: error allowedLanguageTags size equals: 2;
+				assert: error allowedLanguageTags includes: 'en-US' asLanguageTag;
+				assert: error allowedLanguageTags includes: 'es-AR' asLanguageTag
+			]
+]
+
+{ #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingForUnsupportedLanguage [
 
 	| request |
@@ -141,6 +166,40 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglish [
 ]
 
 { #category : #tests }
+SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglishBasedOnAnyLanguageWildcard [
+
+	| response request |
+	request := self
+		           requestToGETResourceIdentifiedBy: 'ARS'
+		           representedAs:
+		           resourceController currencyVersion1dot0dot0MediaType
+						 in: '*'.
+
+	response := resourceController
+		            currencyBasedOn: request
+		            within: self newHttpRequestContext.
+
+	self
+		assert: response isSuccess;
+		assert: response status equals: 200;
+		assert: response contentType asMediaType
+		equals: resourceController currencyVersion1dot0dot0MediaType;
+		withTheOnlyOneIn: response contentLanguageTags
+		do: [ :tag | self assert: tag equals: 'en-US' asLanguageTag ];
+		assert: response varyHeaderNames includes: 'Accept-Language';
+		assert: response varyHeaderNames includes: 'Accept';
+		assert: response entityTag
+		equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
+
+	self withJsonFromContentsIn: response do: [ :json | 
+		self
+			assert: json name equals: 'Argentine peso';
+			assert: json symbol equals: '$';
+			assert: json isoCode equals: 'ARS';
+			assertThereAreNoLinksIn: json ]
+]
+
+{ #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 
 	| response request |
@@ -149,6 +208,40 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 		           representedAs:
 		           resourceController currencyVersion1dot0dot0MediaType
 						 in: 'es'.
+
+	response := resourceController
+		            currencyBasedOn: request
+		            within: self newHttpRequestContext.
+
+	self
+		assert: response isSuccess;
+		assert: response status equals: 200;
+		assert: response contentType asMediaType
+		equals: resourceController currencyVersion1dot0dot0MediaType;
+		withTheOnlyOneIn: response contentLanguageTags
+		do: [ :tag | self assert: tag equals: 'es-AR' asLanguageTag ];
+		assert: response varyHeaderNames includes: 'Accept-Language';
+		assert: response varyHeaderNames includes: 'Accept';
+		assert: response entityTag
+		equals: '"fd65007599711248b85d86917bd24c5aa29e610b"' asEntityTag.
+
+	self withJsonFromContentsIn: response do: [ :json | 
+		self
+			assert: json name equals: 'Peso';
+			assert: json symbol equals: '$';
+			assert: json isoCode equals: 'ARS';
+			assertThereAreNoLinksIn: json ]
+]
+
+{ #category : #tests }
+SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanishBasedOnLanguageQualityPriority [
+
+	| response request |
+	request := self
+		           requestToGETResourceIdentifiedBy: 'ARS'
+		           representedAs:
+		           resourceController currencyVersion1dot0dot0MediaType
+						 in: 'de,en;q=0.5,es;=0.6'.
 
 	response := resourceController
 		            currencyBasedOn: request

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -31,9 +31,10 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 	| request |
 
 	request := self
-		requestToGETResourceIdentifiedBy: 'ARS'
-		accepting: resourceController currencyVersion1dot0dot0MediaType.
-	request setAcceptLanguage: 'de'.
+	           requestToGETResourceIdentifiedBy: 'ARS'
+	           representedAs:
+	           resourceController currencyVersion1dot0dot0MediaType
+	           in: 'de'.
 
 	self
 		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
@@ -111,9 +112,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           accepting:
-		           resourceController currencyVersion1dot0dot0MediaType.
-	request setAcceptLanguage: 'en'.
+		           representedAs:
+		           resourceController currencyVersion1dot0dot0MediaType
+						 in: 'en'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -145,9 +146,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           accepting:
-		           resourceController currencyVersion1dot0dot0MediaType.
-	request setAcceptLanguage: 'es'.
+		           representedAs:
+		           resourceController currencyVersion1dot0dot0MediaType
+						 in: 'es'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -209,9 +210,10 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInEnglish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'BRL'
-		           accepting:
-		           resourceController currencyVersion1dot0dot0MediaType.
-	request setAcceptLanguage: 'en'.
+		           representedAs:
+		           resourceController currencyVersion1dot0dot0MediaType
+						 in: 'en'.
+	
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -243,9 +245,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInSpanish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'BRL'
-		           accepting:
-		           resourceController currencyVersion1dot0dot0MediaType.
-	request setAcceptLanguage: 'es' asLanguageTag.
+		           representedAs:
+		           resourceController currencyVersion1dot0dot0MediaType
+						 in: 'es' asLanguageTag.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -310,8 +312,11 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrenciesInSpanish [
 
 	request := self
 		requestToGET: self resourceUrl
-		accepting: resourceController currencyVersion1dot0dot0MediaType.
-	request setAcceptLanguage: 'es'.
+		applying: [ :requestConfig | 
+			requestConfig
+				setAccept:
+					resourceController currencyVersion1dot0dot0MediaType;
+				setAcceptLanguage: 'es' ].
 
 	response := resourceController currenciesBasedOn: request within: self newHttpRequestContext.
 

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -34,7 +34,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> english [
 { #category : #'private - language ranges' }
 SouthAmericanCurrenciesRESTfulControllerTest >> languageRange [
 
-	^ 'de,en;q=0.5,es;=0.6'
+	^ 'de,en;q=0.5,es;q=0.6'
 ]
 
 { #category : #running }

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Stargate-Examples-Tests-Currencies'
 }
 
+{ #category : #'private - language ranges' }
+SouthAmericanCurrenciesRESTfulControllerTest >> argentineSpanish [
+
+	^ 'es-AR' asLanguageTag 
+]
+
 { #category : #'private - support' }
 SouthAmericanCurrenciesRESTfulControllerTest >> assertThereAreNoLinksIn: json [
 
@@ -19,10 +25,16 @@ SouthAmericanCurrenciesRESTfulControllerTest >> baseUrl [
 	^ 'https://currencies.example.com' asUrl
 ]
 
-{ #category : #'private - support' }
+{ #category : #'private - language ranges' }
 SouthAmericanCurrenciesRESTfulControllerTest >> english [
 
-	^ 'en'
+	^ 'en' asLanguageTag 
+]
+
+{ #category : #'private - language ranges' }
+SouthAmericanCurrenciesRESTfulControllerTest >> languageRange [
+
+	^ 'de,en;q=0.5,es;=0.6'
 ]
 
 { #category : #running }
@@ -31,10 +43,16 @@ SouthAmericanCurrenciesRESTfulControllerTest >> setUpResourceController [
 	resourceController := SouthAmericanCurrenciesRESTfulController new
 ]
 
-{ #category : #'private - support' }
+{ #category : #'private - language ranges' }
 SouthAmericanCurrenciesRESTfulControllerTest >> spanish [
 
-	^ 'es'
+	^ 'es' asLanguageTag 
+]
+
+{ #category : #'private - language ranges' }
+SouthAmericanCurrenciesRESTfulControllerTest >> supportedLanguages [
+
+	^ Array with: self argentineSpanish with: self unitedStatesEnglish
 ]
 
 { #category : #tests }
@@ -43,10 +61,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 	| request |
 
 	request := self
-	           requestToGETResourceIdentifiedBy: 'ARS'
-	           acceptingContentMatching:
-	           resourceController currencyVersion1dot0dot0MediaType
-	           inAnyOf: ''.
+		           requestToGETResourceIdentifiedBy: 'ARS'
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: ''.
 
 	self
 		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
@@ -54,41 +71,32 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 		withExceptionDo: [ :error | 
 			self
 				assert: error messageText
-					equals: 'Cannot generate a response entity with acceptable characteristics.';
+				equals: 'Cannot generate a response entity with acceptable characteristics.';
 				assert: error code equals: 406;
-				assert: error allowedLanguageTags size equals: 2;
-				assert: error allowedLanguageTags includes: 'en-US' asLanguageTag;
-				assert: error allowedLanguageTags includes: 'es-AR' asLanguageTag
+				assertCollection: error allowedLanguageTags hasSameElements: self supportedLanguages
 			]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingForUnsupportedLanguage [
 
-	| request unsupportedLanguage |
-	unsupportedLanguage := 'de'.
+	| request |
 
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
-		           inAnyOf: unsupportedLanguage.
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: self unsupportedLanguage.
 
 	self
-		should: [ 
-			resourceController
-				currencyBasedOn: request
-				within: self newHttpRequestContext ]
+		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
 		raise: HTTPNotAcceptable
 		withExceptionDo: [ :error | 
 			self
 				assert: error messageText
-				equals:
-					'Cannot generate a response entity with acceptable characteristics.';
+				equals: 'Cannot generate a response entity with acceptable characteristics.';
 				assert: error code equals: 406;
-				assert: error allowedLanguageTags size equals: 2;
-				assert: error allowedLanguageTags includes: 'en-US' asLanguageTag;
-				assert: error allowedLanguageTags includes: 'es-AR' asLanguageTag ]
+				assertCollection: error allowedLanguageTags hasSameElements: self supportedLanguages
+			]
 ]
 
 { #category : #tests }
@@ -111,7 +119,7 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePeso [
 		deny: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
 		assert: response entityTag equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag;
-		assertCachingDirectivesFor: response with: #('immutable' 'public').
+		assertCachingDirectivesFor: response with: #( 'immutable' 'public' ).
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
@@ -128,39 +136,36 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoBanknotes [
 	| response |
 
 	response := resourceController
-		currencyBanknotesBasedOn:
-			( self
-				requestToGETSubresource: 'banknotes'
-				identifiedBy: 'ARS'
-				accepting: ZnMimeType applicationJson )
-		within: self newHttpRequestContext.
+		            currencyBanknotesBasedOn: ( self
+				              requestToGETSubresource: 'banknotes'
+				              identifiedBy: 'ARS'
+				              accepting: ZnMimeType applicationJson )
+		            within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
 		assert: response status equals: 200;
 		assert: response contentType asMediaType equals: ZnMimeType applicationJson.
 	self assertExpiresHeaderFor: response with: 365000000 seconds.
-	self assertCachingDirectivesFor: response with: #('immutable' 'public' 'Max-Age=365000000').
+	self assertCachingDirectivesFor: response with: #( 'immutable' 'public' 'Max-Age=365000000' ).
 
 	self
 		withJsonFromContentsIn: response
-		do: [ :banknotes | self assertCollection: banknotes hasSameElements: #(5 10 20 50 100 200 500 1000) ]
+		do: [ :banknotes | 
+		self assertCollection: banknotes hasSameElements: #( 5 10 20 50 100 200 500 1000 ) ]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglish [
 
 	| response request |
-	
+
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
 		           inAnyOf: self english.
 
-	response := resourceController
-		            currencyBasedOn: request
-		            within: self newHttpRequestContext.
+	response := resourceController currencyBasedOn: request within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
@@ -168,33 +173,31 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglish [
 		assert: response contentType asMediaType
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-		do: [ :tag | self assert: tag equals: 'en-US' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self unitedStatesEnglish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
+		assert: response entityTag equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Argentine peso';
 			assert: json symbol equals: '$';
 			assert: json isoCode equals: 'ARS';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglishBasedOnAnyLanguageWildcard [
 
 	| response request |
+
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
-						 inAnyOf: '*'.
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: '*'.
 
-	response := resourceController
-		            currencyBasedOn: request
-		            within: self newHttpRequestContext.
+	response := resourceController currencyBasedOn: request within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
@@ -202,34 +205,31 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglishBas
 		assert: response contentType asMediaType
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-		do: [ :tag | self assert: tag equals: 'en-US' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self unitedStatesEnglish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
+		assert: response entityTag equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Argentine peso';
 			assert: json symbol equals: '$';
 			assert: json isoCode equals: 'ARS';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 
 	| response request |
-	
+
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
 		           inAnyOf: self spanish.
 
-	response := resourceController
-		            currencyBasedOn: request
-		            within: self newHttpRequestContext.
+	response := resourceController currencyBasedOn: request within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
@@ -237,34 +237,31 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 		assert: response contentType asMediaType
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-		do: [ :tag | self assert: tag equals: 'es-AR' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self argentineSpanish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"fd65007599711248b85d86917bd24c5aa29e610b"' asEntityTag.
+		assert: response entityTag equals: '"fd65007599711248b85d86917bd24c5aa29e610b"' asEntityTag.
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Peso';
 			assert: json symbol equals: '$';
 			assert: json isoCode equals: 'ARS';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanishBasedOnLanguagePriorityList [
 
-	| response request languagePriorityList |
-	languagePriorityList := 'de,en;q=0.5,es;=0.6'.
+	| response request |
+
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
-		           inAnyOf: languagePriorityList.
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: self languageRange.
 
-	response := resourceController
-		            currencyBasedOn: request
-		            within: self newHttpRequestContext.
+	response := resourceController currencyBasedOn: request within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
@@ -272,29 +269,29 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanishBas
 		assert: response contentType asMediaType
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-		do: [ :tag | self assert: tag equals: 'es-AR' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self argentineSpanish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"fd65007599711248b85d86917bd24c5aa29e610b"' asEntityTag.
+		assert: response entityTag equals: '"fd65007599711248b85d86917bd24c5aa29e610b"' asEntityTag.
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Peso';
 			assert: json symbol equals: '$';
 			assert: json isoCode equals: 'ARS';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianReal [
 
 	| response |
+
 	response := resourceController
-		            currencyBasedOn: (self
-				             requestToGETResourceIdentifiedBy: 'BRL'
-				             accepting:
-				             resourceController currencyVersion1dot0dot0MediaType)
+		            currencyBasedOn: ( self
+				              requestToGETResourceIdentifiedBy: 'BRL'
+				              accepting: resourceController currencyVersion1dot0dot0MediaType )
 		            within: self newHttpRequestContext.
 
 	self
@@ -304,32 +301,30 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianReal [
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		assert: response contentLanguageTags isEmpty;
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"13bd1a73c317563852cbb2858e39a0af77699f60"' asEntityTag;
-		assertCachingDirectivesFor: response with: #('immutable').
+		assert: response entityTag equals: '"13bd1a73c317563852cbb2858e39a0af77699f60"' asEntityTag;
+		assertCachingDirectivesFor: response with: #( 'immutable' ).
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Brazilian real';
 			assert: json symbol equals: 'R$';
 			assert: json isoCode equals: 'BRL';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInEnglish [
 
 	| response request |
+
 	request := self
 		           requestToGETResourceIdentifiedBy: 'BRL'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
-						 inAnyOf: self english.
-	
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: self english.
 
-	response := resourceController
-		            currencyBasedOn: request
-		            within: self newHttpRequestContext.
+
+	response := resourceController currencyBasedOn: request within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
@@ -337,33 +332,31 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInEnglish [
 		assert: response contentType asMediaType
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-		do: [ :tag | self assert: tag equals: 'en-US' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self unitedStatesEnglish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"13bd1a73c317563852cbb2858e39a0af77699f60"' asEntityTag.
+		assert: response entityTag equals: '"13bd1a73c317563852cbb2858e39a0af77699f60"' asEntityTag.
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Brazilian real';
 			assert: json symbol equals: 'R$';
 			assert: json isoCode equals: 'BRL';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInSpanish [
 
 	| response request |
+
 	request := self
 		           requestToGETResourceIdentifiedBy: 'BRL'
-		           acceptingContentMatching:
-		           resourceController currencyVersion1dot0dot0MediaType
-						 inAnyOf: self spanish.
+		           acceptingContentMatching: resourceController currencyVersion1dot0dot0MediaType
+		           inAnyOf: self spanish.
 
-	response := resourceController
-		            currencyBasedOn: request
-		            within: self newHttpRequestContext.
+	response := resourceController currencyBasedOn: request within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
@@ -371,18 +364,18 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInSpanish [
 		assert: response contentType asMediaType
 		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-		do: [ :tag | self assert: tag equals: 'es-AR' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self argentineSpanish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept';
-		assert: response entityTag
-		equals: '"f74a6f30f3c09515114aa5aa2a47253dfcd59d49"' asEntityTag.
+		assert: response entityTag equals: '"f74a6f30f3c09515114aa5aa2a47253dfcd59d49"' asEntityTag.
 
 	self withJsonFromContentsIn: response do: [ :json | 
 		self
 			assert: json name equals: 'Real brasileño';
 			assert: json symbol equals: 'R$';
 			assert: json isoCode equals: 'BRL';
-			assertThereAreNoLinksIn: json ]
+			assertThereAreNoLinksIn: json
+		]
 ]
 
 { #category : #tests }
@@ -391,30 +384,27 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrencies [
 	| response |
 
 	response := resourceController
-		currenciesBasedOn:
-			( self
-				requestToGET: self resourceUrl
-				accepting: resourceController currencyVersion1dot0dot0MediaType )
-		within: self newHttpRequestContext.
+		            currenciesBasedOn: ( self
+				              requestToGET: self resourceUrl
+				              accepting: resourceController currencyVersion1dot0dot0MediaType )
+		            within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
 		assert: response status equals: 200;
 		assert: response contentType asMediaType
-			equals: resourceController currencyVersion1dot0dot0MediaType;
+		equals: resourceController currencyVersion1dot0dot0MediaType;
 		assert: response contentLanguageTags isEmpty;
 		deny: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept'.
-	self assertCachingDirectivesFor: response with: #('immutable' 'Max-Age=86400').
+	self assertCachingDirectivesFor: response with: #( 'immutable' 'Max-Age=86400' ).
 
-	self
-		withJsonFromContentsIn: response
-		do: [ :currencies | 
-			self
-				assert: currencies size equals: 11;
-				assert: ( currencies collect: #isoCode )
-					equals: #('ARS' 'BOB' 'BRL' 'CLP' 'COP' 'GYD' 'PYG' 'PEN' 'SRD' 'UYU' 'VES')
-			]
+	self withJsonFromContentsIn: response do: [ :currencies | 
+		self
+			assert: currencies size equals: 11;
+			assert: ( currencies collect: #isoCode )
+			equals: #( 'ARS' 'BOB' 'BRL' 'CLP' 'COP' 'GYD' 'PYG' 'PEN' 'SRD' 'UYU' 'VES' )
+		]
 ]
 
 { #category : #tests }
@@ -422,13 +412,11 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrenciesInSpanish [
 
 	| response request |
 
-	request := self
-		requestToGET: self resourceUrl
-		applying: [ :requestConfig | 
-			requestConfig
-				setAccept:
-					resourceController currencyVersion1dot0dot0MediaType;
-				setAcceptLanguage: self spanish ].
+	request := self requestToGET: self resourceUrl applying: [ :requestConfig | 
+		           requestConfig
+			           setAccept: resourceController currencyVersion1dot0dot0MediaType;
+			           setAcceptLanguage: self spanish
+		           ].
 
 	response := resourceController currenciesBasedOn: request within: self newHttpRequestContext.
 
@@ -436,29 +424,28 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrenciesInSpanish [
 		assert: response isSuccess;
 		assert: response status equals: 200;
 		assert: response contentType asMediaType
-			equals: resourceController currencyVersion1dot0dot0MediaType;
+		equals: resourceController currencyVersion1dot0dot0MediaType;
 		withTheOnlyOneIn: response contentLanguageTags
-			do: [ :tag | self assert: tag equals: 'es-AR' asLanguageTag ];
+		do: [ :tag | self assert: tag equals: self argentineSpanish ];
 		assert: response varyHeaderNames includes: 'Accept-Language';
 		assert: response varyHeaderNames includes: 'Accept'.
-	self assertCachingDirectivesFor: response with: #('immutable' 'Max-Age=86400').
+	self assertCachingDirectivesFor: response with: #( 'immutable' 'Max-Age=86400' ).
 
-	self
-		withJsonFromContentsIn: response
-		do: [ :currencies | 
-			self
-				assert: currencies size equals: 11;
-				assert: ( currencies collect: #isoCode )
-					equals: #('ARS' 'BOB' 'BRL' 'CLP' 'COP' 'GYD' 'PYG' 'PEN' 'SRD' 'UYU' 'VES');
-				assert: ( currencies anySatisfy: [ :currency | currency name = 'Real brasileño' ] )
-			]
+	self withJsonFromContentsIn: response do: [ :currencies | 
+		self
+			assert: currencies size equals: 11;
+			assert: ( currencies collect: #isoCode )
+			equals: #( 'ARS' 'BOB' 'BRL' 'CLP' 'COP' 'GYD' 'PYG' 'PEN' 'SRD' 'UYU' 'VES' );
+			assert: ( currencies anySatisfy: [ :currency | currency name = 'Real brasileño' ] )
+		]
 ]
 
 { #category : #tests }
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrencyNotFoundShouldFail [
 
 	self
-		should: [ resourceController
+		should: [ 
+			resourceController
 				currencyBasedOn: ( self requestToGETResourceIdentifiedBy: 'ZZZ' accepting: '*/*' )
 				within: self newHttpRequestContext
 			]
@@ -470,30 +457,27 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetCurrencyNotFoundShouldFai
 SouthAmericanCurrenciesRESTfulControllerTest >> testGetNotModifiedWhenValidETag [
 
 	| response |
+
 	response := resourceController
-		            currencyBasedOn: (self
-				             requestToGETResourceIdentifiedBy: 'ARS'
-				             accepting:
-				             resourceController currencyVersion1dot0dot0MediaType)
+		            currencyBasedOn: ( self
+				              requestToGETResourceIdentifiedBy: 'ARS'
+				              accepting: resourceController currencyVersion1dot0dot0MediaType )
 		            within: self newHttpRequestContext.
 
 	self
 		assert: response isSuccess;
-		assert: response entityTag
-		equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
+		assert: response entityTag equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag.
 
 	response := resourceController
-		            currencyBasedOn: (self
-				             requestToGETResourceIdentifiedBy: 'ARS'
-				             accepting:
-				             resourceController currencyVersion1dot0dot0MediaType
-				             conditionalTo: response entityTag)
+		            currencyBasedOn: ( self
+				              requestToGETResourceIdentifiedBy: 'ARS'
+				              accepting: resourceController currencyVersion1dot0dot0MediaType
+				              conditionalTo: response entityTag )
 		            within: self newHttpRequestContext.
 
 	self
 		assert: response code equals: 304;
-		assert: response entityTag
-		equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag;
+		assert: response entityTag equals: '"5dd07a40a75ea23fa44e641a92a6dd1ec7999a36"' asEntityTag;
 		assert: response varyHeaderNames includes: 'Accept'
 ]
 
@@ -506,7 +490,20 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testTemplates [
 
 	self
 		assertCollection: ( routes collect: #urlTemplate )
-		hasSameElements: #('/currencies' '/currencies/<identifier:IsObject>' '/currencies/<identifier:IsObject>/banknotes').
+		hasSameElements:
+		#( '/currencies' '/currencies/<identifier:IsObject>' '/currencies/<identifier:IsObject>/banknotes' ).
 
 	routes do: [ :route | self assert: route httpMethod equals: #GET ]
+]
+
+{ #category : #'private - language ranges' }
+SouthAmericanCurrenciesRESTfulControllerTest >> unitedStatesEnglish [
+
+	^ 'en-US' asLanguageTag 
+]
+
+{ #category : #'private - language ranges' }
+SouthAmericanCurrenciesRESTfulControllerTest >> unsupportedLanguage [
+
+	^ 'de' asLanguageTag
 ]

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -32,9 +32,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 
 	request := self
 	           requestToGETResourceIdentifiedBy: 'ARS'
-	           representedAs:
+	           acceptingContentMatching:
 	           resourceController currencyVersion1dot0dot0MediaType
-	           in: ''.
+	           and: ''.
 
 	self
 		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
@@ -57,9 +57,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testCantGetArgentinePesoAskingFo
 
 	request := self
 	           requestToGETResourceIdentifiedBy: 'ARS'
-	           representedAs:
+	           acceptingContentMatching:
 	           resourceController currencyVersion1dot0dot0MediaType
-	           in: 'de'.
+	           and: 'de'.
 
 	self
 		should: [ resourceController currencyBasedOn: request within: self newHttpRequestContext ]
@@ -137,9 +137,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           representedAs:
+		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 in: 'en'.
+						 and: 'en'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -171,9 +171,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInEnglishBas
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           representedAs:
+		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 in: '*'.
+						 and: '*'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -205,9 +205,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           representedAs:
+		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 in: 'es'.
+						 and: 'es'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -239,9 +239,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetArgentinePesoInSpanishBas
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'ARS'
-		           representedAs:
+		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 in: 'de,en;q=0.5,es;=0.6'.
+						 and: 'de,en;q=0.5,es;=0.6'.
 
 	response := resourceController
 		            currencyBasedOn: request
@@ -303,9 +303,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInEnglish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'BRL'
-		           representedAs:
+		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 in: 'en'.
+						 and: 'en'.
 	
 
 	response := resourceController
@@ -338,9 +338,9 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetBrazilianRealInSpanish [
 	| response request |
 	request := self
 		           requestToGETResourceIdentifiedBy: 'BRL'
-		           representedAs:
+		           acceptingContentMatching:
 		           resourceController currencyVersion1dot0dot0MediaType
-						 in: 'es' asLanguageTag.
+						 and: 'es' asLanguageTag.
 
 	response := resourceController
 		            currencyBasedOn: request

--- a/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
+++ b/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
@@ -95,7 +95,7 @@ SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdent
 ]
 
 { #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier acceptingContentMatching: aMediaRange and: aLanguageRange [
+SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier acceptingContentMatching: aMediaRange inAnyOf: aLanguageRange [
 
 	^ self
 		  requestToGETResourceIdentifiedBy: anIdentifier

--- a/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
+++ b/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
@@ -46,6 +46,38 @@ SingleResourceRESTfulControllerTest >> requestToGET: aUrl accepting: anAcceptHea
 ]
 
 { #category : #'private - HTTP requests' }
+SingleResourceRESTfulControllerTest >> requestToGET: aUrl applying: aConfiguration [
+
+	^ self
+		  requestToGET: aUrl
+		  withPathParams: Dictionary new
+		  applying: aConfiguration
+]
+
+{ #category : #'private - HTTP requests' }
+SingleResourceRESTfulControllerTest >> requestToGET: aUrl withPathParams: aDictionary applying: aConfiguration [
+	
+	| request | 
+	
+	request := ZnRequest get: aUrl.
+	
+	aConfiguration value: request.
+	
+	^ TeaRequest
+		fromZnRequest: request
+		pathParams: aDictionary.
+]
+
+{ #category : #'private - HTTP requests' }
+SingleResourceRESTfulControllerTest >> requestToGETResourceFrom: aLocation identifiedBy: anIdentifier applying: aConfiguration [
+
+	^ self
+		  requestToGET: aLocation
+		  withPathParams: (self parametersWith: anIdentifier)
+		  applying: aConfiguration
+]
+
+{ #category : #'private - HTTP requests' }
 SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: anAcceptHeader [
 
 	^ TeaRequest
@@ -66,6 +98,27 @@ SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdent
 				setIfNoneMatchTo: anETag;
 				yourself )
 		pathParams: ( self parametersWith: anIdentifier )
+]
+
+{ #category : #'private - HTTP requests' }
+SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier applying: aConfiguration [
+
+	^ self
+		  requestToGETResourceFrom:
+		  (self urlForResourceIdentifiedBy: anIdentifier)
+		  identifiedBy: anIdentifier
+		  applying: aConfiguration
+]
+
+{ #category : #'private - HTTP requests' }
+SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier representedAs: aMediaType in: aLanguageTag [
+
+	^ self
+		  requestToGETResourceIdentifiedBy: anIdentifier
+		  applying: [ :request | 
+			  request
+				  setAccept: aMediaType;
+				  setAcceptLanguage: aLanguageTag ]
 ]
 
 { #category : #'private - HTTP requests' }

--- a/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
+++ b/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
@@ -36,11 +36,11 @@ SingleResourceRESTfulControllerTest >> requestToDELETEResourceIdentifiedBy: anId
 ]
 
 { #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToGET: aUrl accepting: anAcceptHeader [
+SingleResourceRESTfulControllerTest >> requestToGET: aUrl accepting: aMediaRange [
 
 	^ self
 		  requestToGET: aUrl
-		  applying: [ :request | request setAccept: anAcceptHeader ]
+		  applying: [ :request | request setAccept: aMediaRange ]
 ]
 
 { #category : #'private - HTTP requests' }
@@ -76,22 +76,33 @@ SingleResourceRESTfulControllerTest >> requestToGETResourceFrom: aLocation ident
 ]
 
 { #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: anAcceptHeader [
+SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: aMediaRange [
 
 	^ self
 		  requestToGETResourceIdentifiedBy: anIdentifier
-		  applying: [ :request | request setAccept: anAcceptHeader ]
+		  applying: [ :request | request setAccept: aMediaRange ]
 ]
 
 { #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: anAcceptHeader conditionalTo: anETag [
+SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: aMediaRange conditionalTo: anETag [
 
 	^ self
 		  requestToGETResourceIdentifiedBy: anIdentifier
 		  applying: [ :request | 
 			  request
-				  setAccept: anAcceptHeader;
+				  setAccept: aMediaRange;
 				  setIfNoneMatchTo: anETag ]
+]
+
+{ #category : #'private - HTTP requests' }
+SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier acceptingContentMatching: aMediaRange and: aLanguageRange [
+
+	^ self
+		  requestToGETResourceIdentifiedBy: anIdentifier
+		  applying: [ :request | 
+			  request
+				  setAccept: aMediaRange;
+				  setAcceptLanguage: aLanguageRange ]
 ]
 
 { #category : #'private - HTTP requests' }
@@ -105,34 +116,23 @@ SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdent
 ]
 
 { #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier representedAs: aMediaType in: aLanguageTag [
-
-	^ self
-		  requestToGETResourceIdentifiedBy: anIdentifier
-		  applying: [ :request | 
-			  request
-				  setAccept: aMediaType;
-				  setAcceptLanguage: aLanguageTag ]
-]
-
-{ #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToGETSubresource: aSubresourceUrl identifiedBy: anIdentifier accepting: anAcceptHeader [
+SingleResourceRESTfulControllerTest >> requestToGETSubresource: aSubresourceUrl identifiedBy: anIdentifier accepting: aMediaRange [
 
 	^ self
 		  requestToGET: aSubresourceUrl
 		  withPathParams: (self parametersWith: anIdentifier)
-		  applying: [ :request | request setAccept: anAcceptHeader ]
+		  applying: [ :request | request setAccept: aMediaRange ]
 ]
 
 { #category : #'private - HTTP requests' }
-SingleResourceRESTfulControllerTest >> requestToPATCHResourceIdentifiedBy: anIdentifier with: aRequestBody accepting: anAcceptHeader conditionalTo: anETag [
+SingleResourceRESTfulControllerTest >> requestToPATCHResourceIdentifiedBy: anIdentifier with: aRequestBody accepting: aMediaRange conditionalTo: anETag [
 
 	^ TeaRequest
 		fromZnRequest:
 			( ( ZnRequest patch: ( self urlForResourceIdentifiedBy: anIdentifier ) )
-				setAccept: anAcceptHeader;
+				setAccept: aMediaRange;
 				setIfMatchTo: anETag;
-				entity: ( ZnEntity with: aRequestBody type: anAcceptHeader );
+				entity: ( ZnEntity with: aRequestBody type: aMediaRange );
 				yourself )
 		pathParams: ( self parametersWith: anIdentifier )
 ]

--- a/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
+++ b/source/Stargate-SUnit-Model/SingleResourceRESTfulControllerTest.class.st
@@ -38,11 +38,9 @@ SingleResourceRESTfulControllerTest >> requestToDELETEResourceIdentifiedBy: anId
 { #category : #'private - HTTP requests' }
 SingleResourceRESTfulControllerTest >> requestToGET: aUrl accepting: anAcceptHeader [
 
-	^ TeaRequest
-		fromZnRequest:
-			((ZnRequest get: aUrl)
-				setAccept: anAcceptHeader;
-				yourself)
+	^ self
+		  requestToGET: aUrl
+		  applying: [ :request | request setAccept: anAcceptHeader ]
 ]
 
 { #category : #'private - HTTP requests' }
@@ -80,24 +78,20 @@ SingleResourceRESTfulControllerTest >> requestToGETResourceFrom: aLocation ident
 { #category : #'private - HTTP requests' }
 SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: anAcceptHeader [
 
-	^ TeaRequest
-		fromZnRequest:
-			( ( ZnRequest get: ( self urlForResourceIdentifiedBy: anIdentifier ) )
-				setAccept: anAcceptHeader;
-				yourself )
-		pathParams: ( self parametersWith: anIdentifier )
+	^ self
+		  requestToGETResourceIdentifiedBy: anIdentifier
+		  applying: [ :request | request setAccept: anAcceptHeader ]
 ]
 
 { #category : #'private - HTTP requests' }
 SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdentifier accepting: anAcceptHeader conditionalTo: anETag [
 
-	^ TeaRequest
-		fromZnRequest:
-			( ( ZnRequest get: ( self urlForResourceIdentifiedBy: anIdentifier ) )
-				setAccept: anAcceptHeader;
-				setIfNoneMatchTo: anETag;
-				yourself )
-		pathParams: ( self parametersWith: anIdentifier )
+	^ self
+		  requestToGETResourceIdentifiedBy: anIdentifier
+		  applying: [ :request | 
+			  request
+				  setAccept: anAcceptHeader;
+				  setIfNoneMatchTo: anETag ]
 ]
 
 { #category : #'private - HTTP requests' }
@@ -124,12 +118,10 @@ SingleResourceRESTfulControllerTest >> requestToGETResourceIdentifiedBy: anIdent
 { #category : #'private - HTTP requests' }
 SingleResourceRESTfulControllerTest >> requestToGETSubresource: aSubresourceUrl identifiedBy: anIdentifier accepting: anAcceptHeader [
 
-	^ TeaRequest
-		fromZnRequest:
-			( ( ZnRequest get: aSubresourceUrl )
-				setAccept: anAcceptHeader;
-				yourself )
-		pathParams: ( self parametersWith: anIdentifier )
+	^ self
+		  requestToGET: aSubresourceUrl
+		  withPathParams: (self parametersWith: anIdentifier)
+		  applying: [ :request | request setAccept: anAcceptHeader ]
 ]
 
 { #category : #'private - HTTP requests' }


### PR DESCRIPTION
## header-config-for-tests

Changes by Maximo Torterolo Ambrosini on 2023-05-17

### Changes
* added a message that allows to configure get requests of SingleResourceRESTfulControllerTest with a block in order to avoid long messages extended implementations.
* updated internal implementation of requestToGET messages kind with the new configuration block message.
* added tests for covering language support on quality values, wildcard and empty (header sent but with nothing on it)

[Link to branch](https://github.com/maximo-torterolo-ambrosini/Stargate/tree/header-config-for-tests)