### PR TITLE
Return 400/Bad Request when the value received for an ETag (in If-Mat…

### DIFF
--- a/source/Stargate-Examples-Tests/PetsRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/PetsRESTfulControllerTest.class.st
@@ -581,6 +581,19 @@ PetsRESTfulControllerTest >> testGetPetsWithPagination [
 		]
 ]
 
+{ #category : 'tests - update' }
+PetsRESTfulControllerTest >> testInvalidETagFormatMustRaiseBadRequest [
+
+  self
+    createPet;
+    should: [
+        | request |
+        request := self requestToUpdatePetIdentifiedBy: 1 nameTo: 'Mendieta' using: 'invalid'.
+        resourceController updatePetBasedOn: request within: self newHttpRequestContext
+      ]
+    raise: HTTPClientError badRequest
+]
+
 { #category : 'tests - get collection' }
 PetsRESTfulControllerTest >> testPaginationLinksUseServerlUrl [
 

--- a/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
+++ b/source/Stargate-Examples-Tests/SouthAmericanCurrenciesRESTfulControllerTest.class.st
@@ -538,6 +538,21 @@ SouthAmericanCurrenciesRESTfulControllerTest >> testGetNotModifiedWhenValidETag 
 ]
 
 { #category : 'tests' }
+SouthAmericanCurrenciesRESTfulControllerTest >> testInvalidETagFormatMustRaiseBadRequest [
+
+  self
+    should: [
+        | request |
+        request := self
+                     requestToGETResourceIdentifiedBy: 'ARS'
+                     accepting: resourceController currencyVersion1dot0dot0MediaType.
+        request setIfNoneMatchTo: 'invalid'.
+        resourceController currencyBasedOn: request within: self newHttpRequestContext
+      ]
+    raise: HTTPClientError badRequest
+]
+
+{ #category : 'tests' }
 SouthAmericanCurrenciesRESTfulControllerTest >> testTemplates [
 
 	| routes |

--- a/source/Stargate-Model/RESTfulRequestHandlerBehavior.class.st
+++ b/source/Stargate-Model/RESTfulRequestHandlerBehavior.class.st
@@ -132,9 +132,9 @@ RESTfulRequestHandlerBehavior >> entityTagOf: resource encodedAs: mediaType with
 { #category : 'private' }
 RESTfulRequestHandlerBehavior >> entityTagToMatchBasedOn: httpRequest [
 
-	^ (httpRequest headers at: 'If-Match' ifAbsent: [ 
-		   HTTPClientError preconditionRequired signal:
-			   'Missing If-Match header.' ]) asEntityTag
+  ^ self parseEntityTag: ( httpRequest headers
+          at: 'If-Match'
+          ifAbsent: [ HTTPClientError preconditionRequired signal: 'Missing If-Match header.' ] )
 ]
 
 { #category : 'private' }
@@ -266,10 +266,10 @@ RESTfulRequestHandlerBehavior >> holdTargetMediaTypeAndLanguageFrom: httpRequest
 { #category : 'private' }
 RESTfulRequestHandlerBehavior >> ifNoneMatchHeaderPresentIn: httpRequest do: aMonadycBlock [
 
-	httpRequest headers
-		at: 'If-None-Match'
-		ifPresent: [ :ifNoneMatchHeader | 
-			aMonadycBlock value: ifNoneMatchHeader asEntityTag ]
+  httpRequest headers
+    at: 'If-None-Match'
+    ifPresent: [ :ifNoneMatchHeader |
+      aMonadycBlock value: ( self parseEntityTag: ifNoneMatchHeader ) ]
 ]
 
 { #category : 'initialization' }
@@ -302,6 +302,14 @@ RESTfulRequestHandlerBehavior >> locationOf: resource within: requestContext [
 RESTfulRequestHandlerBehavior >> paginationPolicy [
 
 	^ paginationPolicy
+]
+
+{ #category : 'private' }
+RESTfulRequestHandlerBehavior >> parseEntityTag: string [
+
+  ^ [ string asEntityTag ]
+      on: InstanceCreationFailed
+      do: [ :error | HTTPClientError badRequest signal: error messageText ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
…ch or If-None-Match header) is invalid, instead of 500